### PR TITLE
use raw_volume for todoubles

### DIFF
--- a/s_HamsterWebhookRetry【編集禁止】.js
+++ b/s_HamsterWebhookRetry【編集禁止】.js
@@ -26,11 +26,12 @@ function retryWebhook_(){
         var trynum = Number(sheet_value[i][4]) || 1;
 
         var status = status_get_(strategy); //[strategy,active,productcode,volume,time,todoubles,exchange,order_type,lats]
-        var active,productcode,volume,todoubles,exchange,order_type,lats;
+        var active,productcode,raw_volume,volume,todoubles,exchange,order_type,lats;
         if(status){
           active = status[1]; //ON or OFF
           productcode = status[2];
-          volume = Number(status[3]) * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
+          raw_volume = Number(status[3]);
+          volume = raw_volume * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
           todoubles = status[5];
           exchange = status[6];
           order_type = status[7];
@@ -171,7 +172,7 @@ function retryWebhook_(){
               price = 0;
               time = Utilities.formatDate(new Date(), 'JST', "yyyy-MM-dd'T'HH:mm:ss.sss");
               sheet.deleteRow(i+1);
-              todoubles_increase_(todoubles,volume,strategy,exchange);
+              todoubles_increase_(todoubles,raw_volume,strategy,exchange);
               var totalvolume,outstanding;
               try{
                 if(order_type.toUpperCase() == "MARKET"){

--- a/s_HamsterWebhook【編集禁止】.js
+++ b/s_HamsterWebhook【編集禁止】.js
@@ -48,11 +48,12 @@ function doPost(e){
   }
 
   var status = status_get_(strategy); //[strategy,active,productcode,volume,time,todoubles,exchange,order_type,lats]
-  var active,productcode,volume,todoubles,exchange,order_type,lats;
+  var active,productcode,raw_volume,volume,todoubles,exchange,order_type,lats;
   if(status){
     active = status[1]; //ON or OFF
     productcode = status[2];
-    volume = Number(status[3]) * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
+    raw_volume = Number(status[3]);
+    volume = raw_volume * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
     todoubles = status[5];
     exchange = status[6];
     order_type = status[7];
@@ -171,7 +172,7 @@ function doPost(e){
       if (tid){
         price = 0;
         time = Utilities.formatDate(new Date(), 'JST', "yyyy-MM-dd'T'HH:mm:ss.sss");
-        todoubles_increase_(todoubles,volume,strategy,exchange);
+        todoubles_increase_(todoubles,raw_volume,strategy,exchange);
         var totalvolume,outstanding;
         try{
           if(order_type.toUpperCase() == "MARKET"){

--- a/s_Hamster【編集禁止】.js
+++ b/s_Hamster【編集禁止】.js
@@ -76,11 +76,12 @@ function Hamster_(){
         };
 
         var status = status_get_(strategy); //[strategy,active,productcode,volume,time,todoubles,exchange,order_type,lats]
-        var active,productcode,volume,todoubles,exchange,order_type,lats;
+        var active,productcode,raw_volume,volume,todoubles,exchange,order_type,lats;
         if(status){
           active = status[1]; //ON or OFF
           productcode = status[2];
-          volume = Number(status[3]) * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
+          raw_volume = Number(status[3]);
+          volume = raw_volume * Number(leverage); //bitflyerの場合0.01BTC以上、bybitの場合0.0025BTC以上
           todoubles = status[5];
           exchange = status[6];
           order_type = status[7];
@@ -214,7 +215,7 @@ function Hamster_(){
               time = Utilities.formatDate(new Date(), 'JST', "yyyy-MM-dd'T'HH:mm:ss.sss");
               myMessages[i][j].star();
               myMessages[i][j].moveToTrash();
-              todoubles_increase_(todoubles,volume,strategy,exchange);
+              todoubles_increase_(todoubles,raw_volume,strategy,exchange);
               var totalvolume,outstanding;
               try{
                 if(order_type.toUpperCase() == "MARKET"){


### PR DESCRIPTION
### 概要

todoubles が leverage=1 を前提にしているため，
デフォルトストラテジーアラートで想定しない動作をすることが判明しました．

ドテン型のデフォルトストラテジーアラートは，
常に leverage=2 でアラートメッセージが飛んできます．
system は `volume=raw_volume*leverage`で volume を更新し，
このvolumeを2倍する形でスプレッドシートを更新するため，volume が4倍になってしまいます．

回避策として，spreadsheet の volume を raw_volume として保存しておき，
todoubles_increase_() ではこのraw_volumeを引数とするようにします．

### スプレッドシートの更新

無

### 動作確認

~~TODO~~ DONE